### PR TITLE
feat: decouple tool mouse interaction from fixed editor

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -102,13 +102,16 @@ Configuration is stored in `~/.pi/agent/claude-code-style.json`:
 {
   "mode": "on",
   "excludeRenderers": [],
-  "fixedEditorFeatures": true
+  "fixedEditorFeatures": true,
+  "toolMouseInteraction": true
 }
 ```
 
 - `excludeRenderers` uses exact tool names. `Agent` always keeps its dedicated renderer.
-- `fixedEditorFeatures: true` enables `@tifan/pi-fixed-editor` plus mouse scrolling, clicks, viewport mapping, and the back-to-bottom indicator.
-- Set it to `false`, or toggle **Fixed editor** in `/ccstyle`, to restore Pi's native scrolling editor immediately. `Ctrl+End` remains available.
+- `fixedEditorFeatures: true` enables `@tifan/pi-fixed-editor`, which captures mouse input for transcript scrolling and selection.
+- `toolMouseInteraction: true` enables tool hover, click-to-expand, and `Ctrl+End`. With the fixed editor on, it also enables the back-to-bottom indicator and new-message count. With the fixed editor off, it still enables terminal mouse reporting, so native selection requires Shift.
+- Set both options to `false`, or turn **Fixed editor** off in `/ccstyle`, to preserve native terminal wheel scrolling, selection, and context menus. Turning Fixed editor off in the panel also turns Tool mouse off; it can be re-enabled separately.
+- Existing configs without `toolMouseInteraction` inherit the `fixedEditorFeatures` value, so an existing `fixedEditorFeatures: false` config automatically restores native terminal mouse behavior.
 - Run `/reload` after editing the file manually.
 
 ### `@` references

--- a/README.md
+++ b/README.md
@@ -77,6 +77,23 @@ pi install git:github.com/minuque/pi-cc-extensions
 | Session 引用                 | 搜索并注入历史 Session 或现有 SubAgent 的有效上下文                             | `@session:`         |
 | 主题                         | 随包提供内置 GitHub Dark Default 主题                                           | `/theme`            |
 
+### 鼠标交互
+
+配置保存在 `~/.pi/agent/claude-code-style.json`：
+
+```json
+{
+  "fixedEditorFeatures": true,
+  "toolMouseInteraction": true
+}
+```
+
+- `fixedEditorFeatures: true` 启用 `@tifan/pi-fixed-editor`，它会接管鼠标以实现会话滚动和文本选择。
+- `toolMouseInteraction: true` 启用工具悬停、点击展开和 `Ctrl+End`；Fixed editor 开启时还会启用回到底部提示和新消息计数。关闭 Fixed editor 后单独启用它仍会开启终端鼠标报告，原生文本选择需要按住 Shift。
+- 将两项都设为 `false`，或在 `/ccstyle` 面板中关闭 **Fixed editor**，可保留终端原生滚轮、文本选择和右键菜单。面板会同步关闭 **Tool mouse**，之后仍可单独重新启用。
+- 旧配置如果没有 `toolMouseInteraction`，会继承 `fixedEditorFeatures` 的值；因此已有的 `fixedEditorFeatures: false` 会自动恢复终端原生鼠标行为。
+- 手动编辑配置后执行 `/reload`。
+
 ## 本地开发
 
 ```bash

--- a/extensions/claude-code-style.ts
+++ b/extensions/claude-code-style.ts
@@ -54,6 +54,7 @@ export type Config = {
 	mode: CompactStyleMode;
 	excludeRenderers: string[];
 	fixedEditorFeatures: boolean;
+	toolMouseInteraction: boolean;
 	diffViewMode: DiffViewMode;
 	diffIndicatorMode: DiffIndicatorMode;
 	diffSplitMinWidth: number;
@@ -93,6 +94,7 @@ export const DEFAULT_CONFIG: Config = {
 	mode: "on",
 	excludeRenderers: [],
 	fixedEditorFeatures: true,
+	toolMouseInteraction: true,
 	diffViewMode: DEFAULT_TOOL_DISPLAY_CONFIG.diffViewMode,
 	diffIndicatorMode: DEFAULT_TOOL_DISPLAY_CONFIG.diffIndicatorMode,
 	diffSplitMinWidth: DEFAULT_TOOL_DISPLAY_CONFIG.diffSplitMinWidth,
@@ -158,10 +160,15 @@ export function normalizeConfig(input: unknown): Config {
 			]
 		: [];
 	const fixedEditorFeatures = source.fixedEditorFeatures !== false;
+	const toolMouseInteraction =
+		typeof source.toolMouseInteraction === "boolean"
+			? source.toolMouseInteraction
+			: fixedEditorFeatures;
 	return {
 		mode: migratedMode,
 		excludeRenderers,
 		fixedEditorFeatures,
+		toolMouseInteraction,
 		diffViewMode: pickEnum(source.diffViewMode, DIFF_VIEW_MODES, DEFAULT_CONFIG.diffViewMode),
 		diffIndicatorMode: pickEnum(
 			source.diffIndicatorMode,
@@ -228,6 +235,7 @@ export function formatConfigStatus(source: Config = config): string {
 	return [
 		`mode=${source.mode}`,
 		`fixedEditor=${source.fixedEditorFeatures ? "on" : "off"}`,
+		`toolMouse=${source.toolMouseInteraction ? "on" : "off"}`,
 		`exclude=[${source.excludeRenderers.join(", ") || "none"}]`,
 		`diffView=${source.diffViewMode}`,
 		`diffIndicator=${source.diffIndicatorMode}`,
@@ -983,7 +991,7 @@ function withIoViewMarkers(view: ExpandedToolIoView, lines: string[]): string[] 
 
 const TOOL_MOUSE_WIDGET_KEY = "ccstyle-tool-mouse";
 const TOOL_MOUSE_MOTION_ENABLE = "\x1b[?1003h\x1b[?1006h";
-const TOOL_MOUSE_DISABLE = "\x1b[?1006l\x1b[?1003l\x1b[?1000l";
+const TOOL_MOUSE_DISABLE = "\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l";
 const ZENTUI_PAGE_UP_INPUT = /^\x1b\[5;9(?::[12])?~$|^\x1b\[57421;9(?::[12])?u$|^\x1b\[1;6A$/;
 const ZENTUI_PAGE_DOWN_INPUT = /^\x1b\[6;9(?::[12])?~$|^\x1b\[57422;9(?::[12])?u$|^\x1b\[1;6B$/;
 const SCROLL_BOTTOM_SHORTCUT = "ctrl+end";
@@ -1881,7 +1889,10 @@ function handleToolMouseInput(data: string): { consume: true } | undefined {
 	return consumed ? { consume: true } : undefined;
 }
 
-function teardownToolMouseInteraction(nextFixedEditorFeatures = false): void {
+function teardownToolMouseInteraction(
+	nextFixedEditorFeatures = false,
+	nextToolMouseInteraction = false,
+): void {
 	if (sessionRenderTimer) {
 		clearTimeout(sessionRenderTimer);
 		sessionRenderTimer = null;
@@ -1892,7 +1903,7 @@ function teardownToolMouseInteraction(nextFixedEditorFeatures = false): void {
 	setHoveredToolGroup(null);
 	setHoveredToolIo(null, null);
 	try {
-		if (!toolMouseFixedFeaturesEnabled && !nextFixedEditorFeatures) {
+		if (!nextFixedEditorFeatures && !nextToolMouseInteraction) {
 			toolMouseTui?.terminal?.write?.(TOOL_MOUSE_DISABLE);
 		}
 	} catch {
@@ -1922,8 +1933,10 @@ function teardownToolMouseInteraction(nextFixedEditorFeatures = false): void {
 export function installToolMouseInteraction(
 	ctx: any,
 	fixedEditorFeatures = config.fixedEditorFeatures,
+	toolMouseInteraction = config.toolMouseInteraction,
 ): void {
-	teardownToolMouseInteraction(fixedEditorFeatures);
+	teardownToolMouseInteraction(fixedEditorFeatures, toolMouseInteraction);
+	if (!toolMouseInteraction) return;
 	if (ctx?.mode !== "tui" || !ctx?.hasUI) return;
 	if (typeof ctx.ui?.onTerminalInput !== "function" || typeof ctx.ui?.setWidget !== "function")
 		return;
@@ -2014,8 +2027,19 @@ function modeSettingDescription(mode: CompactStyleMode): string {
 
 function fixedEditorSettingDescription(enabled: boolean): string {
 	return enabled
-		? "Pinned editor via @tifan/pi-fixed-editor. Mouse capture, 5-row wheel, tool clicks, back-to-bottom button, message count, and Ctrl+End."
-		: "Native scrolling editor; fixed-editor mouse features and button off. Ctrl+End remains enabled.";
+		? "Pinned editor via @tifan/pi-fixed-editor. Captures mouse input for transcript scrolling and selection."
+		: "Native scrolling editor. Turning this off also disables Tool mouse to restore terminal scrolling and selection.";
+}
+
+function toolMouseSettingDescription(enabled: boolean, fixedEditorEnabled: boolean): string {
+	if (enabled) {
+		return fixedEditorEnabled
+			? "Tool hover, click-to-expand, back-to-bottom button, message count, and Ctrl+End."
+			: "Tool hover and click-to-expand. Captures terminal mouse input; use Shift for native selection.";
+	}
+	return fixedEditorEnabled
+		? "Tool hover and clicks off. The fixed editor still captures mouse input for scrolling and selection."
+		: "Terminal mouse capture off. Native wheel scrolling, selection, and context menus remain available.";
 }
 
 function excludeRenderersDescription(names: readonly string[]): string {
@@ -2150,6 +2174,16 @@ async function showCcstylePanel(
 			currentValue: config.fixedEditorFeatures ? "on" : "off",
 			values: ["on", "off"],
 		};
+		const toolMouseSetting = {
+			id: "toolMouseInteraction",
+			label: "Tool mouse",
+			description: toolMouseSettingDescription(
+				config.toolMouseInteraction,
+				config.fixedEditorFeatures,
+			),
+			currentValue: config.toolMouseInteraction ? "on" : "off",
+			values: ["on", "off"],
+		};
 		// Tracks whether the Exclude-tools submenu is open so Tab switches sections
 		// only at the top level (mirrors Zentui settings: Tab = switch sections).
 		let excludeSubmenuOpen = false;
@@ -2253,7 +2287,15 @@ async function showCcstylePanel(
 					return;
 				case "fixedEditorFeatures":
 					config.fixedEditorFeatures = value === "on";
+					if (!config.fixedEditorFeatures) {
+						config.toolMouseInteraction = false;
+						toolMouseSetting.currentValue = "off";
+					}
 					fixedEditorSetting.description = fixedEditorSettingDescription(
+						config.fixedEditorFeatures,
+					);
+					toolMouseSetting.description = toolMouseSettingDescription(
+						config.toolMouseInteraction,
 						config.fixedEditorFeatures,
 					);
 					saveConfig();
@@ -2261,6 +2303,17 @@ async function showCcstylePanel(
 					installToolMouseInteraction(ctx);
 					refreshCurrentTranscript(compactStyle, ctx);
 					ctx.ui.notify(`Fixed editor: ${value}`, "info");
+					return;
+				case "toolMouseInteraction":
+					config.toolMouseInteraction = value === "on";
+					toolMouseSetting.description = toolMouseSettingDescription(
+						config.toolMouseInteraction,
+						config.fixedEditorFeatures,
+					);
+					saveConfig();
+					installToolMouseInteraction(ctx);
+					refreshCurrentTranscript(compactStyle, ctx);
+					ctx.ui.notify(`Tool mouse: ${value}`, "info");
 					return;
 				case "excludeRenderers":
 					excludeSetting.currentValue = formatExcludeRenderers(config.excludeRenderers);
@@ -2334,7 +2387,7 @@ async function showCcstylePanel(
 			{
 				id: "editor",
 				label: "Editor",
-				items: [fixedEditorSetting],
+				items: [fixedEditorSetting, toolMouseSetting],
 			},
 			{
 				id: "diff",

--- a/tests/compact-style.test.ts
+++ b/tests/compact-style.test.ts
@@ -91,6 +91,7 @@ test("normalizeConfig migrates enabled configs and accepts all three modes", () 
 			mode: "off",
 			excludeRenderers: ["edit"],
 			fixedEditorFeatures: true,
+			toolMouseInteraction: true,
 			...displayDefaults,
 		},
 	);
@@ -98,6 +99,7 @@ test("normalizeConfig migrates enabled configs and accepts all three modes", () 
 		mode: "on",
 		excludeRenderers: [],
 		fixedEditorFeatures: true,
+		toolMouseInteraction: true,
 		...displayDefaults,
 	});
 	assert.deepEqual(
@@ -106,6 +108,7 @@ test("normalizeConfig migrates enabled configs and accepts all three modes", () 
 			mode: "compact",
 			excludeRenderers: ["Agent"],
 			fixedEditorFeatures: true,
+			toolMouseInteraction: true,
 			...displayDefaults,
 		},
 	);
@@ -113,12 +116,24 @@ test("normalizeConfig migrates enabled configs and accepts all three modes", () 
 		mode: "off",
 		excludeRenderers: [],
 		fixedEditorFeatures: false,
+		toolMouseInteraction: false,
 		...displayDefaults,
 	});
+	assert.equal(
+		normalizeConfig({ fixedEditorFeatures: false, toolMouseInteraction: true })
+			.toolMouseInteraction,
+		true,
+	);
+	assert.equal(
+		normalizeConfig({ fixedEditorFeatures: true, toolMouseInteraction: false })
+			.toolMouseInteraction,
+		false,
+	);
 	assert.deepEqual(normalizeConfig({ mode: "unknown" }), {
 		mode: "on",
 		excludeRenderers: [],
 		fixedEditorFeatures: true,
+		toolMouseInteraction: true,
 		...displayDefaults,
 	});
 	assert.deepEqual(
@@ -138,6 +153,7 @@ test("normalizeConfig migrates enabled configs and accepts all three modes", () 
 			mode: "on",
 			excludeRenderers: [],
 			fixedEditorFeatures: true,
+			toolMouseInteraction: true,
 			diffViewMode: "split",
 			diffIndicatorMode: "classic",
 			diffSplitMinWidth: 140,
@@ -932,7 +948,11 @@ test("ccstyle registers compact mode and no ctrl+shift+o shortcut", async () => 
 		},
 	};
 
-	claudeCodeStyleExtension(pi as any, { fixedEditorFeatures: true });
+	claudeCodeStyleExtension(pi as any, {
+		mode: "on",
+		fixedEditorFeatures: true,
+		toolMouseInteraction: true,
+	});
 	const command = commands.get("ccstyle");
 	assert.deepEqual(
 		command.getArgumentCompletions("").map((item: any) => item.value),
@@ -974,7 +994,10 @@ test("ccstyle registers compact mode and no ctrl+shift+o shortcut", async () => 
 	assert.ok(
 		panelLines.some((line: string) => line.includes("Fixed editor") && line.includes("on")),
 	);
-	assert.ok(panelLines.some((line: string) => line.includes("Mouse capture")));
+	assert.ok(panelLines.some((line: string) => line.includes("Captures mouse input")));
+	assert.ok(panelLines.some((line: string) => line.includes("Tool mouse") && line.includes("on")));
+	panel.handleInput("\x1b[B");
+	panelLines = panel.render(80).map((line: string) => line.trimEnd());
 	assert.ok(panelLines.some((line: string) => line.includes("Ctrl+End")));
 	// Tab → Diff section
 	panel.handleInput("\t");

--- a/tests/mouse-config-panel.test.ts
+++ b/tests/mouse-config-panel.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+
+initTheme("dark");
+
+test("turning off Fixed editor also disables Tool mouse and persists both", async () => {
+	const configDir = mkdtempSync(join(tmpdir(), "pi-ccstyle-mouse-"));
+	const previousConfigDir = process.env.PI_CODING_AGENT_DIR;
+	const stdoutWrite = process.stdout.write;
+	process.env.PI_CODING_AGENT_DIR = configDir;
+	process.stdout.write = (() => true) as typeof process.stdout.write;
+
+	try {
+		const extensionPath = "../extensions/claude-code-style.ts?mouse-panel-test";
+		const { default: claudeCodeStyleExtension } = await import(extensionPath);
+		const commands = new Map<string, any>();
+		const events = new Map<string, Function[]>();
+		const pi = {
+			registerCommand(name: string, options: any) {
+				commands.set(name, options);
+			},
+			registerShortcut() {},
+			registerEntryRenderer() {},
+			on(name: string, handler: Function) {
+				const handlers = events.get(name) ?? [];
+				handlers.push(handler);
+				events.set(name, handlers);
+			},
+		};
+		claudeCodeStyleExtension(pi as any, {
+			mode: "on",
+			fixedEditorFeatures: true,
+			toolMouseInteraction: true,
+		});
+
+		let panel: any;
+		const widgetValues = new Map<string, unknown[]>();
+		let mouseListenerRegistrations = 0;
+		let activeMouseListeners = 0;
+		const theme = {
+			fg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+		};
+		const ctx = {
+			mode: "tui",
+			hasUI: true,
+			ui: {
+				theme,
+				custom(factory: Function) {
+					panel = factory({ requestRender() {} }, theme, {}, () => undefined);
+					return Promise.resolve();
+				},
+				notify() {},
+				requestRender() {},
+				setStatus() {},
+				setWidget(key: string, value: unknown) {
+					const values = widgetValues.get(key) ?? [];
+					values.push(value);
+					widgetValues.set(key, values);
+				},
+				onTerminalInput() {
+					mouseListenerRegistrations++;
+					activeMouseListeners++;
+					return () => {
+						activeMouseListeners--;
+					};
+				},
+			},
+		};
+
+		for (const handler of events.get("session_start") ?? []) {
+			await handler({ reason: "startup" }, ctx);
+		}
+		assert.equal(mouseListenerRegistrations, 1);
+		assert.equal(activeMouseListeners, 1);
+
+		await commands.get("ccstyle").handler("", ctx);
+		panel.handleInput("\t");
+		panel.handleInput("\r");
+		assert.equal(activeMouseListeners, 0);
+		assert.equal(widgetValues.get("ccstyle-tool-mouse")?.at(-1), undefined);
+
+		for (const handler of events.get("session_compact") ?? []) {
+			await handler({}, ctx);
+		}
+		assert.equal(mouseListenerRegistrations, 1);
+		assert.equal(activeMouseListeners, 0);
+
+		const saved = JSON.parse(
+			readFileSync(join(configDir, "claude-code-style.json"), "utf8"),
+		) as Record<string, unknown>;
+		assert.equal(saved.fixedEditorFeatures, false);
+		assert.equal(saved.toolMouseInteraction, false);
+
+		const lines = panel
+			.render(80)
+			.join("\n")
+			.replace(/\x1b\[[0-9;]*m/g, "");
+		assert.match(lines, /Fixed editor\s+off/);
+		assert.match(lines, /Tool mouse\s+off/);
+
+		for (const handler of events.get("session_shutdown") ?? []) {
+			await handler({}, ctx);
+		}
+	} finally {
+		process.stdout.write = stdoutWrite;
+		if (previousConfigDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousConfigDir;
+		rmSync(configDir, { recursive: true, force: true });
+	}
+});

--- a/tests/mouse-fixed-editor.test.ts
+++ b/tests/mouse-fixed-editor.test.ts
@@ -21,7 +21,7 @@ import { installToolGrouping, ToolGroupComponent } from "../extensions/tool-grou
 initTheme("dark");
 
 test("fixed editor wheel dispatch averages five rows per tick", () => {
-	installToolMouseInteraction({}, false);
+	installToolMouseInteraction({}, false, false);
 	assert.deepEqual((["up", "up", "up"] as const).map(fixedEditorWheelDispatchCount), [1, 2, 2]);
 	assert.deepEqual(
 		(["down", "down", "down"] as const).map(fixedEditorWheelDispatchCount),
@@ -161,7 +161,10 @@ test("tool click uses fixed-editor visible rows without previousViewportTop", as
 		},
 	};
 
-	claudeCodeStyleExtension(pi as any, { fixedEditorFeatures: true });
+	claudeCodeStyleExtension(pi as any, {
+		fixedEditorFeatures: true,
+		toolMouseInteraction: true,
+	});
 	await events.get("session_start")?.({}, { mode: "tui", hasUI: true, ui });
 	class SnapshotCompositor {
 		tui = tui;
@@ -347,6 +350,7 @@ test("identical fixed-editor tools hit the visible first tool, not the offscreen
 			},
 		},
 		true,
+		true,
 	);
 	class SnapshotCompositor {
 		tui = tui;
@@ -368,7 +372,7 @@ test("identical fixed-editor tools hit the visible first tool, not the offscreen
 		assert.equal(expanded, "visible-first");
 		assert.equal(offscreen.expanded, false);
 	} finally {
-		installToolMouseInteraction({}, false);
+		installToolMouseInteraction({}, false, false);
 	}
 });
 
@@ -423,6 +427,7 @@ test("fixed editor uses the rendered frame when dynamic Todo rows change", () =>
 			},
 		},
 		true,
+		true,
 	);
 	try {
 		tui.doRender();
@@ -437,7 +442,7 @@ test("fixed editor uses the rendered frame when dynamic Todo rows change", () =>
 		assert.equal(first.expanded, false);
 		assert.equal(second.expanded, true);
 	} finally {
-		installToolMouseInteraction({}, false);
+		installToolMouseInteraction({}, false, false);
 	}
 });
 
@@ -493,6 +498,7 @@ test("tool groups expand from their hint and collapse from any expanded group ro
 				},
 			},
 			false,
+			true,
 		);
 		tui.doRender();
 		const headerRow = tui.previousLines.findIndex((line: string) =>
@@ -511,7 +517,7 @@ test("tool groups expand from their hint and collapse from any expanded group ro
 		assert.equal(inputHandler?.(`\x1b[<0;100;${bottomPaddingRow + 1}M`)?.consume, true);
 		assert.equal(group.expanded, false);
 	} finally {
-		installToolMouseInteraction({}, false);
+		installToolMouseInteraction({}, false, false);
 		grouping.shutdown();
 	}
 });
@@ -562,6 +568,7 @@ test("truncated tool summary remains clickable and highlights on hover", async (
 			},
 		},
 		false,
+		true,
 	);
 	tui.doRender();
 
@@ -584,7 +591,7 @@ test("truncated tool summary remains clickable and highlights on hover", async (
 	assert.deepEqual(inputHandler?.("\x1b[<0;30;2M"), { consume: true });
 	assert.equal(tool.expanded, true);
 
-	installToolMouseInteraction({}, false);
+	installToolMouseInteraction({}, false, false);
 });
 
 test("parenthesized rich diff hint highlights and expands on click", async () => {
@@ -630,6 +637,7 @@ test("parenthesized rich diff hint highlights and expands on click", async () =>
 			},
 		},
 		false,
+		true,
 	);
 	try {
 		tui.doRender();
@@ -639,7 +647,7 @@ test("parenthesized rich diff hint highlights and expands on click", async () =>
 		assert.deepEqual(inputHandler?.("\x1b[<0;35;2M"), { consume: true });
 		assert.equal(tool.expanded, true);
 	} finally {
-		installToolMouseInteraction({}, false);
+		installToolMouseInteraction({}, false, false);
 	}
 });
 
@@ -704,13 +712,13 @@ test("show-more hover targets the view rendered in the current frame after compa
 			},
 		},
 	};
-	installToolMouseInteraction(interactionCtx, true);
+	installToolMouseInteraction(interactionCtx, true, true);
 	// fixed-editor can retain the prior doRender wrapper while compact installs a new one.
 	const retainedRender = tui.doRender;
 	tui.doRender = function (this: any, ...args: any[]) {
 		return Reflect.apply(retainedRender, this, args);
 	};
-	installToolMouseInteraction(interactionCtx, true);
+	installToolMouseInteraction(interactionCtx, true, true);
 	try {
 		tui.doRender();
 		const inputHeader = tui.previousLines[1];
@@ -719,7 +727,7 @@ test("show-more hover targets the view rendered in the current frame after compa
 		assert.match(currentView.render(78)[0], /\x1b\[97m/);
 		assert.doesNotMatch(staleView.render(78)[0], /\x1b\[97m/);
 	} finally {
-		installToolMouseInteraction({}, false);
+		installToolMouseInteraction({}, false, false);
 	}
 });
 
@@ -790,13 +798,13 @@ test("expanded native card collapses on click and preserves the viewport", async
 		},
 	};
 
-	installToolMouseInteraction(ctx, true);
+	installToolMouseInteraction(ctx, true, true);
 	tui.doRender();
 	tui.handleInput("\x1b[<0;10;2M");
 	await new Promise<void>((resolve) => process.nextTick(resolve));
 	assert.equal(tool.expanded, false);
 	assert.equal(wheelDownDispatches, 1);
-	installToolMouseInteraction({}, false);
+	installToolMouseInteraction({}, false, false);
 });
 
 test("fixed editor restores motion reporting after the right-click menu pause", async () => {
@@ -849,7 +857,7 @@ test("fixed editor restores motion reporting after the right-click menu pause", 
 	assert.equal(writes.at(-1), "\x1b[?1002h", "dispose restores the native terminal writer");
 });
 
-test("disabled fixed editor features release mouse reporting but retain Ctrl+End", () => {
+test("native tool mouse mode retains capture and Ctrl+End after fixed editor is disabled", () => {
 	const writes: string[] = [];
 	const widgetValues: unknown[] = [];
 	const renderRequests: unknown[] = [];
@@ -885,10 +893,10 @@ test("disabled fixed editor features release mouse reporting but retain Ctrl+End
 		},
 	};
 
-	installToolMouseInteraction(ctx, true);
+	installToolMouseInteraction(ctx, true, true);
 	assert.ok(!writes.some((value) => value.includes("?1000h")));
 	const disabledWritesStart = writes.length;
-	installToolMouseInteraction(ctx, false);
+	installToolMouseInteraction(ctx, false, true);
 	const disabledWrites = writes.slice(disabledWritesStart);
 	assert.ok(!disabledWrites.some((value) => value.includes("?1000l")));
 	assert.ok(disabledWrites.some((value) => value.includes("?1003h")));
@@ -899,7 +907,106 @@ test("disabled fixed editor features release mouse reporting but retain Ctrl+End
 	assert.equal(writes.at(-1), "\x1b[0m");
 	assert.deepEqual(renderRequests, [undefined]);
 
-	installToolMouseInteraction({}, false);
+	installToolMouseInteraction({}, false, false);
+});
+
+test("tool mouse off releases reporting and cannot re-enable it on render", () => {
+	const writes: string[] = [];
+	const widgetValues: unknown[] = [];
+	let inputHandler: ((data: string) => { consume?: boolean } | undefined) | undefined;
+	let renderCalls = 0;
+	const originalDoRender = () => {
+		renderCalls++;
+	};
+	const tui = {
+		terminal: {
+			columns: 80,
+			rows: 24,
+			write(value: string) {
+				writes.push(value);
+			},
+		},
+		children: [],
+		previousLines: [] as string[],
+		previousViewportTop: 0,
+		handleInput() {},
+		requestRender() {},
+		render: () => [] as string[],
+		doRender: originalDoRender,
+	};
+	const ctx = {
+		mode: "tui",
+		hasUI: true,
+		ui: {
+			setWidget(_key: string, value: any) {
+				widgetValues.push(value);
+				if (typeof value === "function") {
+					value(tui, { fg: (_color: string, text: string) => text });
+				}
+			},
+			onTerminalInput(handler: (data: string) => { consume?: boolean } | undefined) {
+				inputHandler = handler;
+				return () => {
+					if (inputHandler === handler) inputHandler = undefined;
+				};
+			},
+		},
+	};
+
+	try {
+		installToolMouseInteraction(ctx, false, true);
+		assert.notEqual(tui.doRender, originalDoRender);
+		tui.doRender();
+		assert.ok(writes.some((value) => value.includes("?1003h") && value.includes("?1006h")));
+
+		const disabledWritesStart = writes.length;
+		installToolMouseInteraction(ctx, false, false);
+		const disabledWrites = writes.slice(disabledWritesStart).join("");
+		assert.match(disabledWrites, /\?1006l/);
+		assert.match(disabledWrites, /\?1003l/);
+		assert.match(disabledWrites, /\?1002l/);
+		assert.match(disabledWrites, /\?1000l/);
+		assert.doesNotMatch(disabledWrites, /\?100[236]h/);
+		assert.equal(tui.doRender, originalDoRender);
+		assert.equal(inputHandler, undefined);
+		assert.equal(widgetValues.at(-1), undefined);
+
+		const enableWrites = writes.filter((value) => /\?100[236]h/.test(value)).length;
+		tui.doRender();
+		assert.equal(renderCalls, 2);
+		assert.equal(
+			writes.filter((value) => /\?100[236]h/.test(value)).length,
+			enableWrites,
+			"renders after disabling must not re-enable mouse reporting",
+		);
+	} finally {
+		installToolMouseInteraction({}, false, false);
+	}
+});
+
+test("tool mouse off leaves fixed-editor mouse ownership untouched", () => {
+	let widgetCalls = 0;
+	let inputListenerCalls = 0;
+	installToolMouseInteraction(
+		{
+			mode: "tui",
+			hasUI: true,
+			ui: {
+				setWidget() {
+					widgetCalls++;
+				},
+				onTerminalInput() {
+					inputListenerCalls++;
+					return () => undefined;
+				},
+			},
+		},
+		true,
+		false,
+	);
+	assert.equal(widgetCalls, 0);
+	assert.equal(inputListenerCalls, 0);
+	installToolMouseInteraction({}, false, false);
 });
 
 test("doRender replacement is rebound so the next painted frame stays clickable", () => {
@@ -950,14 +1057,14 @@ test("doRender replacement is rebound so the next painted frame stays clickable"
 			},
 		},
 	};
-	installToolMouseInteraction(ctx, true);
+	installToolMouseInteraction(ctx, true, true);
 	const firstWrapper = tui.doRender;
 	// Compositor rebuild replaces doRender; the old instrumentation must not stick to a dead wrapper.
 	const compositorDoRender = function (this: any) {
 		this.previousLines = this.render(80);
 	};
 	tui.doRender = compositorDoRender;
-	installToolMouseInteraction(ctx, true);
+	installToolMouseInteraction(ctx, true, true);
 	try {
 		assert.notEqual(tui.doRender, firstWrapper);
 		assert.notEqual(tui.doRender, compositorDoRender);
@@ -966,7 +1073,7 @@ test("doRender replacement is rebound so the next painted frame stays clickable"
 		tui.handleInput(`\x1b[<0;${hintCol};2M`);
 		assert.equal(expanded, "after-rebind");
 	} finally {
-		installToolMouseInteraction({}, false);
+		installToolMouseInteraction({}, false, false);
 	}
 });
 
@@ -1058,6 +1165,7 @@ test("expanded tool group show-more opens preview instead of collapsing the grou
 				},
 			},
 			false,
+			true,
 		);
 		tui.doRender();
 		const showMoreRow = tui.previousLines.findIndex((line: string) =>
@@ -1071,7 +1179,7 @@ test("expanded tool group show-more opens preview instead of collapsing the grou
 		assert.equal(group.expanded, beforeExpanded, "show-more must not collapse the group");
 		assert.equal(previewOpened, true, "show-more opens the text preview");
 	} finally {
-		installToolMouseInteraction({}, false);
+		installToolMouseInteraction({}, false, false);
 		grouping.shutdown();
 	}
 });
@@ -1122,6 +1230,7 @@ test("native mode hits the visible identical tool, not the offscreen duplicate",
 			},
 		},
 		false,
+		true,
 	);
 	try {
 		tui.doRender();
@@ -1131,7 +1240,7 @@ test("native mode hits the visible identical tool, not the offscreen duplicate",
 		assert.equal(expanded, "native-visible");
 		assert.equal(offscreen.expanded, false);
 	} finally {
-		installToolMouseInteraction({}, false);
+		installToolMouseInteraction({}, false, false);
 	}
 });
 
@@ -1183,6 +1292,7 @@ test("native mode hits offset columns after parent layout prefix", async () => {
 			},
 		},
 		false,
+		true,
 	);
 	try {
 		tui.doRender();
@@ -1209,7 +1319,7 @@ test("native mode hits offset columns after parent layout prefix", async () => {
 		assert.deepEqual(inputHandler?.(`\x1b[<0;${offsetCol};2M`), { consume: true });
 		assert.equal(tool.expanded, true);
 	} finally {
-		installToolMouseInteraction({}, false);
+		installToolMouseInteraction({}, false, false);
 	}
 });
 
@@ -1309,6 +1419,7 @@ test("expanded group identical show-more labels open their own content", () => {
 				},
 			},
 			false,
+			true,
 		);
 		tui.doRender();
 		assert.ok(
@@ -1339,7 +1450,7 @@ test("expanded group identical show-more labels open their own content", () => {
 			"second show-more must not open first body",
 		);
 	} finally {
-		installToolMouseInteraction({}, false);
+		installToolMouseInteraction({}, false, false);
 		grouping.shutdown();
 	}
 });
@@ -1435,10 +1546,10 @@ test("footer rebuild and fixed toggle do not stack inactive doRender wrappers", 
 		};
 		// Mirror extension wiring: unwrap before construct, re-wrap after install.
 		setBeforeFixedEditorStart(() => {
-			installToolMouseInteraction({}, false);
+			installToolMouseInteraction({}, false, false);
 		});
 		controller.onRebuild(() => {
-			installToolMouseInteraction(ctx, true);
+			installToolMouseInteraction(ctx, true, true);
 			const factory = widgets.get("ccstyle-tool-mouse");
 			if (typeof factory === "function") {
 				factory(tui, { fg: (_c: string, text: string) => text });
@@ -1464,7 +1575,7 @@ test("footer rebuild and fixed toggle do not stack inactive doRender wrappers", 
 
 		// fixed on → off → on
 		controller.setEnabled(false);
-		installToolMouseInteraction(ctx, false);
+		installToolMouseInteraction(ctx, false, true);
 		const factoryOff = widgets.get("ccstyle-tool-mouse");
 		if (typeof factoryOff === "function") {
 			factoryOff(tui, { fg: (_c: string, text: string) => text });
@@ -1482,7 +1593,7 @@ test("footer rebuild and fixed toggle do not stack inactive doRender wrappers", 
 
 		// Hover/click on the live chain after fixed off restores a single wrapper.
 		controller.setEnabled(false);
-		installToolMouseInteraction(ctx, false);
+		installToolMouseInteraction(ctx, false, true);
 		const factoryNative = widgets.get("ccstyle-tool-mouse");
 		if (typeof factoryNative === "function") {
 			factoryNative(tui, { fg: (_c: string, text: string) => text });
@@ -1504,6 +1615,6 @@ test("footer rebuild and fixed toggle do not stack inactive doRender wrappers", 
 	} finally {
 		process.stdout.write = write;
 		setBeforeFixedEditorStart(undefined);
-		installToolMouseInteraction({}, false);
+		installToolMouseInteraction({}, false, false);
 	}
 });


### PR DESCRIPTION
## Summary

Splits tool mouse interaction (hover, click-to-expand, back-to-bottom indicator, Ctrl+End) out of the fixed-editor feature so each can be toggled independently.

- **New `toolMouseInteraction` config**; when absent it inherits `fixedEditorFeatures`, so existing configs keep their behavior (notably `fixedEditorFeatures: false` restores native terminal mouse behavior automatically).
- **`/ccstyle` panel**: new "Tool mouse" toggle in the Editor section. Turning Fixed editor off also turns Tool mouse off (can be re-enabled separately).
- **Teardown** now emits all mouse release sequences (`?1006l ?1003l ?1002l ?1000l`) when both features are off, and later renders never re-enable reporting after disable.
- README (zh/en) and tests updated; new `tests/mouse-config-panel.test.ts` covers panel联动 + persistence.

## Test

- `npm test`: 106/106 pass
- `npm run format:check`: clean
- `npm run typecheck`: passes (only pre-existing non-fatal issues ignored)