### PR TITLE
fix: prevent compact thinking recursion after reload

### DIFF
--- a/extensions/compact-style.ts
+++ b/extensions/compact-style.ts
@@ -917,7 +917,16 @@ function patchAssistantMessageComponent(
 			return patch.nativeUpdateContent.call(this, message);
 		}
 		if (!patch.active || !installation.active || state.activeInstallation !== installation) {
-			return patch.originalUpdateContent.call(this, message);
+			// A downstream renderer may have captured this wrapper, then been
+			// restored after compact teardown. Mark the pass-through re-entry so
+			// that downstream -> stale compact -> downstream cycles bottom out at
+			// Pi's native renderer instead of overflowing the stack.
+			this[ASSISTANT_REENTRY_KEY] = patch;
+			try {
+				return patch.originalUpdateContent.call(this, message);
+			} finally {
+				delete this[ASSISTANT_REENTRY_KEY];
+			}
 		}
 
 		state.assistantComponents.add(this);

--- a/tests/compact-style.test.ts
+++ b/tests/compact-style.test.ts
@@ -579,6 +579,39 @@ test("compact reclaims assistant rendering after a later thinking extension patc
 	}
 });
 
+test("stale compact wrapper breaks downstream restoration cycles", () => {
+	const prototype = AssistantMessageComponent.prototype as any;
+	const originalUpdateContent = prototype.updateContent;
+	const hooks = installCompactStyle({} as any, {
+		getMode: () => "off",
+		getExcludeRenderers: () => [],
+	});
+	const compactUpdateContent = prototype.updateContent;
+	const downstreamRenderer = function (this: any, message: any) {
+		return compactUpdateContent.call(this, message);
+	};
+	const ctx = createContext(createUi());
+
+	try {
+		prototype.updateContent = downstreamRenderer;
+		hooks.onSessionStart({}, ctx);
+		hooks.onSessionShutdown({}, ctx);
+
+		// Mirrors pi-compact-thinking shutdown: it restores the compact wrapper
+		// captured when the downstream renderer was installed.
+		prototype.updateContent = compactUpdateContent;
+		assert.doesNotThrow(
+			() =>
+				new AssistantMessageComponent(
+					assistantMessage([{ type: "text", text: "after reload" }]),
+					true,
+				),
+		);
+	} finally {
+		prototype.updateContent = originalUpdateContent;
+	}
+});
+
 test("compact restores contentText for tools without definitions", () => {
 	let mode: CompactStyleMode = "compact";
 	const ui = createUi();


### PR DESCRIPTION
## Summary

Prevent an inactive compact-style wrapper from recursively calling a downstream `pi-compact-thinking` renderer that captured the same wrapper before teardown.

The failure appears after shutdown/reload restoration creates this cycle:

```text
stale compact wrapper -> downstream thinking wrapper -> stale compact wrapper
```

The inactive pass-through now uses the existing assistant re-entry guard, so the second entry bottoms out at Pi’s native renderer instead of overflowing the stack.

## Regression test

Adds a lifecycle test that reproduces the downstream restoration order used by `pi-compact-thinking`, then renders a new assistant message after shutdown. The test fails with `RangeError: Maximum call stack size exceeded` before the fix.

## Validation

- full upstream test suite: 109/109 passed
- installed `pi-cc-extensions@0.8.37` hotfix is LSP-clean and matches the tested source change