### PR TITLE
fix: only animate tool calls whose execution started

### DIFF
--- a/extensions/renderer/compact-mode.ts
+++ b/extensions/renderer/compact-mode.ts
@@ -490,7 +490,8 @@ function compactEditWriteLine(
 				: "",
 	);
 	const isError = component.result?.isError === true;
-	const isPending = !component.result || component.isPartial === true;
+	const isPending =
+		component.executionStarted && (!component.result || component.isPartial === true);
 	const icon = isError ? "✗" : isPending ? toolLoadingIcon() : "✓";
 	const iconColor = isError ? "error" : isPending ? "accent" : "success";
 	let statsText = "";
@@ -1136,7 +1137,8 @@ export function installCompactMode(deps: CompactModeInstallDeps): CompactModeHoo
 		}
 		const name = String(this.toolName ?? "");
 		if (EDIT_WRITE_TOOLS.has(name)) {
-			if (!this.result || this.isPartial === true) scheduleAnimation(this);
+			if (this.executionStarted && (!this.result || this.isPartial === true))
+				scheduleAnimation(this);
 			return compactEditWriteLines(this, width, deps.writeMetadata);
 		}
 		// Agent/Task 等同普通工具：折叠不外置（live 面板走独立 widget）。

--- a/extensions/renderer/compact-mode.ts
+++ b/extensions/renderer/compact-mode.ts
@@ -492,8 +492,9 @@ function compactEditWriteLine(
 	const isError = component.result?.isError === true;
 	const isPending =
 		component.executionStarted && (!component.result || component.isPartial === true);
-	const icon = isError ? "✗" : isPending ? toolLoadingIcon() : "✓";
-	const iconColor = isError ? "error" : isPending ? "accent" : "success";
+	const isSettled = component.result !== undefined;
+	const icon = isError ? "✗" : isPending ? toolLoadingIcon() : isSettled ? "✓" : "●";
+	const iconColor = isError ? "error" : isPending ? "accent" : isSettled ? "success" : "muted";
 	let statsText = "";
 	let statsStyled = "";
 	if (!isError && !isPending) {

--- a/extensions/renderer/default-mode.ts
+++ b/extensions/renderer/default-mode.ts
@@ -232,7 +232,9 @@ function createCcstyleTool(
 			const visualState = resolveToolVisualState(context);
 			const isPending =
 				visualState === "pending" ||
-				(!visualState && (context?.isPartial || context?.executionStarted));
+				(!visualState &&
+					context?.executionStarted &&
+					(context?.isPartial || context?.result === undefined));
 			if (isPending) scheduleAnimation(context);
 			const rawIcon = isPending ? pendingIcon(toolName) : settledIcon(toolName, visualState);
 			const icon =

--- a/extensions/renderer/default-mode.ts
+++ b/extensions/renderer/default-mode.ts
@@ -232,9 +232,7 @@ function createCcstyleTool(
 			const visualState = resolveToolVisualState(context);
 			const isPending =
 				visualState === "pending" ||
-				(!visualState &&
-					context?.executionStarted &&
-					(context?.isPartial || context?.result === undefined));
+				(!visualState && context?.executionStarted && context?.isPartial !== false);
 			if (isPending) scheduleAnimation(context);
 			const rawIcon = isPending ? pendingIcon(toolName) : settledIcon(toolName, visualState);
 			const icon =

--- a/extensions/renderer/tool/grouping.ts
+++ b/extensions/renderer/tool/grouping.ts
@@ -69,8 +69,8 @@ type ToolStatus = "pending" | "success" | "error";
 
 function status(tool: any): ToolStatus {
 	if (tool?.result?.isError) return "error";
-	if (tool?.isPartial === true || (tool?.executionStarted && !tool?.result)) return "pending";
-	return tool?.result ? "success" : "pending";
+	if (tool?.executionStarted && (tool?.isPartial === true || !tool?.result)) return "pending";
+	return "success";
 }
 
 function statusIcon(value: ToolStatus): string {

--- a/extensions/renderer/tool/grouping.ts
+++ b/extensions/renderer/tool/grouping.ts
@@ -11,6 +11,7 @@ import { isToolTuiFullscreen, showMoreHintText } from "./show-more-hint.ts";
 import { stripAnsi, stripBackgroundAnsi, stripLeadingStatusIcon } from "../../utils/ansi-text.ts";
 import { walkComponentTree } from "../../utils/component-tree.ts";
 import { humanizeToolLabel, toolCallSummary } from "./names.ts";
+import { isRestoredToolCall, markRestoredToolCall } from "./result.ts";
 import {
 	patchRegistry,
 	TOOL_GROUPING_GENERATION_KEY as GENERATION_KEY,
@@ -65,18 +66,21 @@ function previousSibling(
 	return undefined;
 }
 
-type ToolStatus = "pending" | "success" | "error";
+type ToolStatus = "queued" | "pending" | "success" | "error" | "skipped";
 
 function status(tool: any): ToolStatus {
 	if (tool?.result?.isError) return "error";
-	if (tool?.executionStarted && (tool?.isPartial === true || !tool?.result)) return "pending";
-	return "success";
+	if (tool?.result) return "success";
+	if (isRestoredToolCall(tool)) return "skipped";
+	if (tool?.executionStarted) return "pending";
+	return "queued";
 }
 
 function statusIcon(value: ToolStatus): string {
 	if (value === "success") return "✓";
 	if (value === "error") return "✗";
-	return toolLoadingIcon();
+	if (value === "pending") return toolLoadingIcon();
+	return "●";
 }
 
 function scheduleGroupAnimation(patch: Patch): void {
@@ -280,22 +284,51 @@ export class ToolGroupComponent extends Container {
 		if (cached) return cached;
 		const theme = this.patch.theme;
 		const fg = (color: string, text: string) => theme?.fg?.(color, text) ?? text;
-		const counts = { pending: 0, success: 0, error: 0 };
+		const counts: Record<ToolStatus, number> = {
+			queued: 0,
+			pending: 0,
+			success: 0,
+			error: 0,
+			skipped: 0,
+		};
 		for (const tool of this.children) counts[status(tool)]++;
-		const countText = (["pending", "success", "error"] as const)
+		const countText = (["pending", "queued", "success", "error", "skipped"] as const)
 			.filter((key) => counts[key])
 			.map((key) => {
-				const label = key === "pending" ? "running" : key === "success" ? "done" : "failed";
-				const color = key === "pending" ? "accent" : key;
+				const label =
+					key === "pending"
+						? "running"
+						: key === "queued"
+							? "queued"
+							: key === "success"
+								? "done"
+								: key === "error"
+									? "failed"
+									: "skipped";
+				const color =
+					key === "pending" ? "accent" : key === "queued" || key === "skipped" ? "muted" : key;
 				return `${fg(color, String(counts[key]))} ${label}`;
 			})
 			.join(` ${fg("dim", "•")} `);
 		const names = new Set(this.children.map(toolName));
 		const label =
 			names.size === 1 ? humanizeToolLabel(toolName(this.children[0])) : "Multiple Tools";
-		const overall: ToolStatus = counts.error ? "error" : counts.pending ? "pending" : "success";
+		const overall: ToolStatus = counts.error
+			? "error"
+			: counts.pending
+				? "pending"
+				: counts.success
+					? "success"
+					: counts.queued
+						? "queued"
+						: "skipped";
 		if (overall === "pending") scheduleGroupAnimation(this.patch);
-		const overallColor = overall === "pending" ? "accent" : overall;
+		const overallColor =
+			overall === "pending"
+				? "accent"
+				: overall === "queued" || overall === "skipped"
+					? "muted"
+					: overall;
 		const nameList = names.size > 1 ? ` ${fg("dim", `• ${toolNameList(this.children)}`)}` : "";
 		// 圆点保持 dim；hover 只高亮可点击文字。
 		const hint = `${fg("dim", "•")} ${fg(this.hintHovered ? "text" : "dim", showMoreHintText())}`;
@@ -312,7 +345,12 @@ export class ToolGroupComponent extends Container {
 		for (let index = 0; index < total; index++) {
 			const tool = this.children[index];
 			const toolStatus = status(tool);
-			const color = toolStatus === "pending" ? "accent" : toolStatus;
+			const color =
+				toolStatus === "pending"
+					? "accent"
+					: toolStatus === "queued" || toolStatus === "skipped"
+						? "muted"
+						: toolStatus;
 			const branch = index === total - 1 ? "└" : "├";
 			const continuation = index === total - 1 ? "  " : "│ ";
 			if (!this._expanded) {
@@ -433,6 +471,9 @@ function regroup(patch: Patch, root: any): void {
 		if (Array.isArray(children)) {
 			for (const child of [...children]) {
 				if (child && typeof child === "object") child[PARENT_KEY] = value;
+				if (isGroupable(child) && !child.executionStarted && !child.result) {
+					markRestoredToolCall(child);
+				}
 				maybeGroup(patch, value, child);
 			}
 		}

--- a/extensions/renderer/tool/result.ts
+++ b/extensions/renderer/tool/result.ts
@@ -79,6 +79,18 @@ function clearAnimation(context: any) {
 	}
 }
 
+const RESTORED_TOOL_STATE_KEY = "ccstyleRestoredToolCall";
+
+export function markRestoredToolCall(context: any): void {
+	const state = (context.state ??= {});
+	state[RESTORED_TOOL_STATE_KEY] = true;
+	clearAnimation(context);
+}
+
+export function isRestoredToolCall(context: any): boolean {
+	return context?.state?.[RESTORED_TOOL_STATE_KEY] === true;
+}
+
 export function clearAllAnimations() {
 	for (const ctx of activeAnimationContexts) {
 		ctx.state.ccstyleAnimationScheduled = false;
@@ -149,7 +161,7 @@ export function toolIconColor(context: any): "accent" | "error" | "success" | "m
 	const visualState = getToolVisualState(context);
 	if (context?.isError || visualState === "error") return "error";
 	if (visualState === "success") return "success";
-	if (context?.isPartial || context?.executionStarted || visualState === "pending") return "accent";
+	if (context?.executionStarted || visualState === "pending") return "accent";
 	return "muted";
 }
 

--- a/tests/compact-mode.test.ts
+++ b/tests/compact-mode.test.ts
@@ -613,6 +613,22 @@ test("compact surfaces abort outside folded tools", () => {
 	}
 });
 
+test("queued compact edit/write stays neutral until execution starts", () => {
+	const previousMode = config.mode;
+	config.mode = "compact";
+	const hooks = installCompactMode({ writeMetadata: new WriteExecutionMetadataStore() });
+	try {
+		const edit = tool("edit", "queued-edit", { path: "a.ts" });
+		assert.match(renderText(edit).join("\n"), /● edit a\.ts/);
+
+		edit.markExecutionStarted();
+		assert.match(renderText(edit).join("\n"), /[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏] edit a\.ts/);
+	} finally {
+		config.mode = previousMode;
+		hooks.shutdown();
+	}
+});
+
 test("compact edit/write keeps the stats header and inherits on-mode diff limits", () => {
 	const metadata = new WriteExecutionMetadataStore();
 	const previousMode = config.mode;

--- a/tests/tool-grouping.test.ts
+++ b/tests/tool-grouping.test.ts
@@ -96,28 +96,55 @@ test("mixed tools group across three empty separators while edit/write and conte
 	}
 });
 
-test("restored tool calls that never started render settled, not running", () => {
+test("queued live tools stay neutral until execution starts", () => {
 	const hooks = installToolGrouping(() => true);
 	try {
 		const parent = new Container() as any;
-		const read = staleTool("read", "read-stale");
-		const bash = staleTool("bash", "bash-stale");
+		const read = staleTool("read", "read-queued");
+		const bash = staleTool("bash", "bash-queued");
 		parent.addChild(read);
 		parent.addChild(bash);
+		const group = parent.children[0] as ToolGroupComponent;
+		const queued = group
+			.render(100)
+			.map((line: string) => line.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, ""))
+			.filter((line: string) => line.trim());
+		assert.match(queued[0], /2 queued/);
+		for (const line of queued) assert.doesNotMatch(line, /[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏✓]/);
+
+		read.markExecutionStarted();
+		bash.markExecutionStarted();
+		const running = group
+			.render(100)
+			.map((line: string) => line.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, ""))
+			.filter((line: string) => line.trim());
+		assert.match(running[0], /2 running/);
+		assert.ok(running.some((line: string) => /[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/.test(line)));
+	} finally {
+		hooks.shutdown();
+	}
+});
+
+test("restored tool calls that never started render skipped, not running", () => {
+	const parent = new Container() as any;
+	parent.addChild(staleTool("read", "read-stale"));
+	parent.addChild(staleTool("bash", "bash-stale"));
+	const hooks = installToolGrouping(() => true);
+	try {
+		hooks.refresh(parent);
 		const group = parent.children[0] as ToolGroupComponent;
 		const rendered = group
 			.render(100)
 			.map((line: string) => line.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, ""))
 			.filter((line: string) => line.trim());
-		assert.match(rendered[0], /2 done/);
-		assert.doesNotMatch(rendered[0], /running/);
+		assert.match(rendered[0], /2 skipped/);
+		assert.doesNotMatch(rendered[0], /running|done/);
 		for (const line of rendered) {
-			assert.doesNotMatch(
-				line,
-				/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/,
-				"no spinner for restored tools",
-			);
+			assert.doesNotMatch(line, /[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏✓]/, "restored tools stay neutral");
 		}
+
+		(group.children[0] as any).updateResult({ content: [], isError: false });
+		assert.match(group.render(100).find((line: string) => line.trim())!, /1 done.*1 skipped/);
 	} finally {
 		hooks.shutdown();
 	}

--- a/tests/tool-grouping.test.ts
+++ b/tests/tool-grouping.test.ts
@@ -12,6 +12,22 @@ import { installToolGrouping, ToolGroupComponent } from "../extensions/renderer/
 initTheme("dark");
 const ui = { theme: { fg: (_color: string, text: string) => text }, requestRender() {} } as any;
 function tool(name: string, id: string, args: any = {}) {
+	const component = new ToolExecutionComponent(
+		name,
+		id,
+		args,
+		{},
+		undefined,
+		ui,
+		process.cwd(),
+	) as any;
+	// pi marks executions started on tool_execution_start, before any render
+	component.markExecutionStarted();
+	return component;
+}
+
+/** Restored tool call that never ran in this process (no tool_execution_start). */
+function staleTool(name: string, id: string, args: any = {}) {
 	return new ToolExecutionComponent(name, id, args, {}, undefined, ui, process.cwd()) as any;
 }
 
@@ -75,6 +91,33 @@ test("mixed tools group across three empty separators while edit/write and conte
 		parent.addChild(assistant);
 		parent.addChild(tool("bash", "after-content"));
 		assert.equal(parent.children.at(-1).toolCallId, "after-content");
+	} finally {
+		hooks.shutdown();
+	}
+});
+
+test("restored tool calls that never started render settled, not running", () => {
+	const hooks = installToolGrouping(() => true);
+	try {
+		const parent = new Container() as any;
+		const read = staleTool("read", "read-stale");
+		const bash = staleTool("bash", "bash-stale");
+		parent.addChild(read);
+		parent.addChild(bash);
+		const group = parent.children[0] as ToolGroupComponent;
+		const rendered = group
+			.render(100)
+			.map((line: string) => line.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, ""))
+			.filter((line: string) => line.trim());
+		assert.match(rendered[0], /2 done/);
+		assert.doesNotMatch(rendered[0], /running/);
+		for (const line of rendered) {
+			assert.doesNotMatch(
+				line,
+				/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/,
+				"no spinner for restored tools",
+			);
+		}
 	} finally {
 		hooks.shutdown();
 	}

--- a/tests/tool-renderer-ownership.test.ts
+++ b/tests/tool-renderer-ownership.test.ts
@@ -86,6 +86,7 @@ test("expanded ccstyle tools use Pi's native background card", async () => {
 			ui as any,
 			process.cwd(),
 		) as any;
+		component.markExecutionStarted();
 		assert.match(
 			component
 				.render(100)

--- a/tests/tool-renderer-ownership.test.ts
+++ b/tests/tool-renderer-ownership.test.ts
@@ -86,6 +86,13 @@ test("expanded ccstyle tools use Pi's native background card", async () => {
 			ui as any,
 			process.cwd(),
 		) as any;
+		const queuedCall = component
+			.render(100)
+			.join("\n")
+			.replace(/\x1b\[[0-9;]*m/g, "");
+		assert.match(queuedCall, /● Bash /);
+		assert.doesNotMatch(queuedCall, /[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏✓]/);
+
 		component.markExecutionStarted();
 		assert.match(
 			component


### PR DESCRIPTION
Restored tool calls that never received a result (interrupted runs, forks) were treated as pending, so the shared 80 ms loading timer re-armed on every render and kept re-rendering the frame with no input.

Only treat a tool as pending while its execution started; restored calls do not have executionStarted set.
