### PR TITLE
feat: optional dim thinking text

### DIFF
--- a/extensions/config/config.ts
+++ b/extensions/config/config.ts
@@ -47,6 +47,7 @@ export type Config = {
 	useSummaryTitlesAsThinkingTitle: boolean;
 	previewLines: number;
 	animationIntervalMs: number;
+	dimThinkingText: boolean;
 	showStartupHeader: boolean;
 	scrollStepLines: number;
 	enableSessionReference: boolean;
@@ -95,6 +96,7 @@ export const DEFAULT_CONFIG: Config = {
 	useSummaryTitlesAsThinkingTitle: true,
 	previewLines: 3,
 	animationIntervalMs: 90,
+	dimThinkingText: false,
 	showStartupHeader: true,
 	scrollStepLines: 3,
 	enableSessionReference: true,
@@ -182,6 +184,7 @@ export function normalizeConfig(input: unknown): Config {
 			source.animationIntervalMs,
 			DEFAULT_CONFIG.animationIntervalMs,
 		),
+		dimThinkingText: source.dimThinkingText === true,
 		showStartupHeader: source.showStartupHeader !== false,
 		scrollStepLines: pickPositiveInt(source.scrollStepLines, DEFAULT_CONFIG.scrollStepLines, 1, 50),
 		enableSessionReference: source.enableSessionReference !== false,

--- a/extensions/config/panel.ts
+++ b/extensions/config/panel.ts
@@ -6,10 +6,7 @@
  */
 import { getSettingsListTheme } from "@earendil-works/pi-coding-agent";
 import { Input, SettingsList, matchesKey, truncateToWidth } from "@earendil-works/pi-tui";
-import {
-	applyThinkingTextDim,
-	clearThinkingTextDim,
-} from "../feature/thinking-text-dim.ts";
+import { applyThinkingTextDim, clearThinkingTextDim } from "../feature/thinking-text-dim.ts";
 import type { CompactThinkingController } from "../feature/compact-thinking.ts";
 import { applyStartupHeader } from "../feature/shell/startup-header.ts";
 import type { ToolGroupingHooks } from "../renderer/tool/grouping.ts";

--- a/extensions/config/panel.ts
+++ b/extensions/config/panel.ts
@@ -6,6 +6,10 @@
  */
 import { getSettingsListTheme } from "@earendil-works/pi-coding-agent";
 import { Input, SettingsList, matchesKey, truncateToWidth } from "@earendil-works/pi-tui";
+import {
+	applyThinkingTextDim,
+	clearThinkingTextDim,
+} from "../feature/thinking-text-dim.ts";
 import type { CompactThinkingController } from "../feature/compact-thinking.ts";
 import { applyStartupHeader } from "../feature/shell/startup-header.ts";
 import type { ToolGroupingHooks } from "../renderer/tool/grouping.ts";
@@ -340,6 +344,15 @@ export async function showCcstylePanel(
 			submenu: (_current: string, closeSubmenu: (selected?: string) => void) =>
 				buildNumberInputSubmenu(theme, thinkingAnimationSetting, closeSubmenu),
 		};
+		const thinkingDimSetting = {
+			id: "dimThinkingText",
+			label: "Dim thinking text",
+			description: config.dimThinkingText
+				? "Thinking text uses the theme's dim color."
+				: "Keep the default thinking text color.",
+			currentValue: config.dimThinkingText ? "on" : "off",
+			values: ["on", "off"],
+		};
 		const startupHeaderSetting = {
 			id: "showStartupHeader",
 			label: "Startup header",
@@ -483,6 +496,18 @@ export async function showCcstylePanel(
 					});
 					thinkingAnimationSetting.currentValue = String(config.animationIntervalMs);
 					break;
+				case "dimThinkingText":
+					updateConfig({ dimThinkingText: value === "on" });
+					thinkingDimSetting.currentValue = String(config.dimThinkingText);
+					thinkingDimSetting.description = config.dimThinkingText
+						? "Thinking text uses the theme's dim color."
+						: "Keep the default thinking text color.";
+					if (config.dimThinkingText) {
+						applyThinkingTextDim(ctx.ui.theme);
+					} else {
+						clearThinkingTextDim(ctx.ui.theme);
+					}
+					break;
 				case "showStartupHeader":
 					updateConfig({ showStartupHeader: value === "on" });
 					startupHeaderSetting.description = config.showStartupHeader
@@ -526,7 +551,12 @@ export async function showCcstylePanel(
 			{
 				id: "thinking",
 				label: "Thinking",
-				items: [thinkingTitleSetting, thinkingPreviewSetting, thinkingAnimationSetting],
+				items: [
+					thinkingTitleSetting,
+					thinkingPreviewSetting,
+					thinkingAnimationSetting,
+					thinkingDimSetting,
+				],
 			},
 			{
 				id: "feature",

--- a/extensions/feature/thinking-text-dim.ts
+++ b/extensions/feature/thinking-text-dim.ts
@@ -1,0 +1,47 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { config } from "../config/config.ts";
+
+/**
+ * Optional dimming of thinking-block text via the `thinkingText` theme token.
+ *
+ * Every thinking-text renderer reads the same token — pi's built-in
+ * visible-mode renderer and the compact thinking preview — so setting it to
+ * the theme's dim color dims thinking text everywhere. The token is
+ * re-asserted on render-triggering events because the theme instance can be
+ * replaced mid-session (theme reload), which would otherwise reset it.
+ */
+
+export function applyThinkingTextDim(theme: any): void {
+	try {
+		if (!config.dimThinkingText || !theme?.fgColors?.set) return;
+		const dim = theme.fgColors.get?.("dim") ?? theme.fgColors.get?.("muted");
+		if (typeof dim === "string" && dim.length > 0) {
+			theme.fgColors.set("thinkingText", dim);
+		}
+	} catch {
+		/* theme not ready yet */
+	}
+}
+
+export function clearThinkingTextDim(theme: any): void {
+	try {
+		theme?.fgColors?.delete?.("thinkingText");
+	} catch {
+		/* theme not ready yet */
+	}
+}
+
+function assertOnRenderEvents(_event: unknown, ctx: any): void {
+	applyThinkingTextDim(ctx?.ui?.theme);
+}
+
+export default function installThinkingTextDim(pi: ExtensionAPI): void {
+	pi.on("session_start", (_event, ctx) => {
+		if (ctx.mode !== "tui" || !ctx.hasUI) return;
+		applyThinkingTextDim(ctx.ui.theme);
+	});
+	pi.on("session_tree", assertOnRenderEvents);
+	pi.on("message_update", assertOnRenderEvents);
+	pi.on("message_end", assertOnRenderEvents);
+	pi.on("tool_execution_end", assertOnRenderEvents);
+}

--- a/extensions/feature/thinking-text-dim.ts
+++ b/extensions/feature/thinking-text-dim.ts
@@ -1,47 +1,47 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+	Theme,
+	ThemeColor,
+} from "@earendil-works/pi-coding-agent";
 import { config } from "../config/config.ts";
 
-/**
- * Optional dimming of thinking-block text via the `thinkingText` theme token.
- *
- * Every thinking-text renderer reads the same token — pi's built-in
- * visible-mode renderer and the compact thinking preview — so setting it to
- * the theme's dim color dims thinking text everywhere. The token is
- * re-asserted on render-triggering events because the theme instance can be
- * replaced mid-session (theme reload), which would otherwise reset it.
- */
+type MutableTheme = { fgColors?: Map<ThemeColor, string> };
 
-export function applyThinkingTextDim(theme: any): void {
-	try {
-		if (!config.dimThinkingText || !theme?.fgColors?.set) return;
-		const dim = theme.fgColors.get?.("dim") ?? theme.fgColors.get?.("muted");
-		if (typeof dim === "string" && dim.length > 0) {
-			theme.fgColors.set("thinkingText", dim);
-		}
-	} catch {
-		/* theme not ready yet */
-	}
+const originalThinkingTextAnsi = new WeakMap<Theme, string>();
+
+function colorMap(theme: Theme): Map<ThemeColor, string> | undefined {
+	const colors = (theme as unknown as MutableTheme).fgColors;
+	return colors instanceof Map ? colors : undefined;
 }
 
-export function clearThinkingTextDim(theme: any): void {
-	try {
-		theme?.fgColors?.delete?.("thinkingText");
-	} catch {
-		/* theme not ready yet */
+export function applyThinkingTextDim(theme: Theme): void {
+	const colors = colorMap(theme);
+	if (!colors) return;
+
+	if (!originalThinkingTextAnsi.has(theme)) {
+		originalThinkingTextAnsi.set(theme, theme.getFgAnsi("thinkingText"));
 	}
+	colors.set("thinkingText", theme.getFgAnsi("dim"));
 }
 
-function assertOnRenderEvents(_event: unknown, ctx: any): void {
-	applyThinkingTextDim(ctx?.ui?.theme);
+export function clearThinkingTextDim(theme: Theme): void {
+	const colors = colorMap(theme);
+	const original = originalThinkingTextAnsi.get(theme);
+	if (!colors || original === undefined) return;
+
+	colors.set("thinkingText", original);
+	originalThinkingTextAnsi.delete(theme);
+}
+
+function syncThinkingTextDim(ctx: ExtensionContext): void {
+	if (config.dimThinkingText) applyThinkingTextDim(ctx.ui.theme);
+	else clearThinkingTextDim(ctx.ui.theme);
 }
 
 export default function installThinkingTextDim(pi: ExtensionAPI): void {
-	pi.on("session_start", (_event, ctx) => {
+	pi.on("session_start", async (_event, ctx) => {
 		if (ctx.mode !== "tui" || !ctx.hasUI) return;
-		applyThinkingTextDim(ctx.ui.theme);
+		syncThinkingTextDim(ctx);
 	});
-	pi.on("session_tree", assertOnRenderEvents);
-	pi.on("message_update", assertOnRenderEvents);
-	pi.on("message_end", assertOnRenderEvents);
-	pi.on("tool_execution_end", assertOnRenderEvents);
 }

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -12,6 +12,7 @@ import agentSummary from "./feature/agent-summary/index.ts";
 import context from "./feature/context.ts";
 import sessionReference from "./feature/reference/index.ts";
 import { installCompactThinking } from "./feature/compact-thinking.ts";
+import installThinkingTextDim from "./feature/thinking-text-dim.ts";
 
 // renderer
 import claudeCodeStyle, { getCompactThinkingConfig } from "./renderer/index.ts";
@@ -26,6 +27,7 @@ export default function (pi: ExtensionAPI): void {
 	// render stack：thinking controller 直接交给 style 作 query
 	markdownEnhance(pi);
 	claudeCodeStyle(pi, undefined, installCompactThinking(pi, getCompactThinkingConfig()));
+	installThinkingTextDim(pi);
 
 	// features
 	if (config.enableContextCommand) context(pi);

--- a/extensions/renderer/compact-mode.ts
+++ b/extensions/renderer/compact-mode.ts
@@ -70,7 +70,8 @@ export function styleCompactThinkingText(
 	bold = false,
 ): string {
 	if (!theme) return text;
-	const colored = typeof theme.fg === "function" ? theme.fg("thinkingText", text) : text;
+	const colorKey = config.dimThinkingText ? "dim" : "thinkingText";
+	const colored = typeof theme.fg === "function" ? theme.fg(colorKey, text) : text;
 	const weighted = bold && typeof theme.bold === "function" ? theme.bold(colored) : colored;
 	return typeof theme.italic === "function" ? theme.italic(weighted) : weighted;
 }

--- a/extensions/renderer/compact-mode.ts
+++ b/extensions/renderer/compact-mode.ts
@@ -70,8 +70,7 @@ export function styleCompactThinkingText(
 	bold = false,
 ): string {
 	if (!theme) return text;
-	const colorKey = config.dimThinkingText ? "dim" : "thinkingText";
-	const colored = typeof theme.fg === "function" ? theme.fg(colorKey, text) : text;
+	const colored = typeof theme.fg === "function" ? theme.fg("thinkingText", text) : text;
 	const weighted = bold && typeof theme.bold === "function" ? theme.bold(colored) : colored;
 	return typeof theme.italic === "function" ? theme.italic(weighted) : weighted;
 }

--- a/tests/thinking-text-dim.test.ts
+++ b/tests/thinking-text-dim.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { config } from "../extensions/config/config.ts";
+import installThinkingTextDim, {
+	applyThinkingTextDim,
+	clearThinkingTextDim,
+} from "../extensions/feature/thinking-text-dim.ts";
+
+function theme() {
+	const colors = new Map<string, string>([
+		["thinkingText", "\x1b[95m"],
+		["dim", "\x1b[2m"],
+	]);
+	return {
+		colors,
+		theme: {
+			fgColors: colors,
+			getFgAnsi(color: string) {
+				const ansi = colors.get(color);
+				if (ansi === undefined) throw new Error(`Unknown theme color: ${color}`);
+				return ansi;
+			},
+			fg(color: string, text: string) {
+				return `${this.getFgAnsi(color)}${text}\x1b[0m`;
+			},
+		},
+	};
+}
+
+test("restores the original thinkingText ANSI", () => {
+	const original = "\x1b[95m";
+	const state = theme();
+
+	applyThinkingTextDim(state.theme as any);
+	applyThinkingTextDim(state.theme as any);
+	assert.equal(state.colors.get("thinkingText"), "\x1b[2m");
+
+	clearThinkingTextDim(state.theme as any);
+	assert.equal(state.colors.get("thinkingText"), original);
+	assert.equal(state.theme.fg("thinkingText", "text"), `${original}text\x1b[0m`);
+});
+
+test("syncs only on session start", async () => {
+	const handlers = new Map<string, (...args: any[]) => unknown>();
+	installThinkingTextDim({
+		on(event: string, handler: (...args: any[]) => unknown) {
+			handlers.set(event, handler);
+		},
+	} as any);
+	assert.deepEqual([...handlers.keys()], ["session_start"]);
+
+	const state = theme();
+	const ctx = { mode: "tui", hasUI: true, ui: { theme: state.theme } };
+	const originalSetting = config.dimThinkingText;
+	try {
+		config.dimThinkingText = true;
+		await handlers.get("session_start")?.({}, ctx);
+		await handlers.get("session_start")?.({}, ctx);
+		assert.equal(state.colors.get("thinkingText"), "\x1b[2m");
+
+		config.dimThinkingText = false;
+		await handlers.get("session_start")?.({}, ctx);
+		assert.equal(state.colors.get("thinkingText"), "\x1b[95m");
+	} finally {
+		config.dimThinkingText = originalSetting;
+	}
+});


### PR DESCRIPTION
Thinking text renders at the theme's thinkingText color, which is often close to the body-text brightness.

Add a dimThinkingText option (default off, /ccstyle → Thinking) that renders thinking text with the theme's dim color instead.
