### PR TITLE
perf: cache historical thinking previews

### DIFF
--- a/extensions/feature/compact-thinking.ts
+++ b/extensions/feature/compact-thinking.ts
@@ -174,10 +174,37 @@ function thinkingExpandAction(): string | undefined {
 }
 
 // 只 wrap 尾部窗口；缓存未着色折行，着色放到取出时做，避免主题切换命中旧 ANSI。
-const previewCache = new Map<string, { lines: string[]; hiddenBefore: number }>();
-const PREVIEW_CACHE_MAX = 500;
+type PreviewCacheEntry = { lines: string[]; hiddenBefore: number };
+const previewCache = new Map<string, PreviewCacheEntry>();
+export const THINKING_PREVIEW_CACHE_MAX = 2_048;
 const PREVIEW_BUDGET_MIN_CHARS = 2_000;
 const PREVIEW_BUDGET_SLACK_LINES = 2;
+
+function getCachedPreview(key: string): PreviewCacheEntry | undefined {
+	const entry = previewCache.get(key);
+	if (!entry) return undefined;
+	previewCache.delete(key);
+	previewCache.set(key, entry);
+	return entry;
+}
+
+function cachePreview(key: string, entry: PreviewCacheEntry): void {
+	previewCache.delete(key);
+	while (previewCache.size >= THINKING_PREVIEW_CACHE_MAX) {
+		const oldest = previewCache.keys().next().value;
+		if (oldest === undefined) break;
+		previewCache.delete(oldest);
+	}
+	previewCache.set(key, entry);
+}
+
+export function clearThinkingPreviewCache(): void {
+	previewCache.clear();
+}
+
+export function thinkingPreviewCacheSize(): number {
+	return previewCache.size;
+}
 
 /** 按可见宽度估算折行数，不走 Text 全量 wrap。无换行长段也能计到隐藏行。 */
 function countWrappedLines(text: string, contentWidth: number): number {
@@ -219,14 +246,13 @@ function layoutThinkingPreview(
 		else cut = 0;
 	}
 	const cacheKey = `${width}:${padding}:${cut}:${source}`;
-	let entry = previewCache.get(cacheKey);
+	let entry = getCachedPreview(cacheKey);
 	if (!entry) {
 		entry = {
 			lines: wrapTextWithAnsi(source.replace(/\t/g, "   "), contentWidth),
 			hiddenBefore: cut > 0 ? countWrappedLines(text.slice(0, cut), contentWidth) : 0,
 		};
-		if (previewCache.size >= PREVIEW_CACHE_MAX) previewCache.clear();
-		previewCache.set(cacheKey, entry);
+		cachePreview(cacheKey, entry);
 	}
 	const hiddenLines = entry.hiddenBefore + Math.max(0, entry.lines.length - config.previewLines);
 	const visible = hiddenLines > 0 ? entry.lines.slice(-config.previewLines) : entry.lines;
@@ -265,6 +291,15 @@ export class ThinkingPreviewBlock implements Component {
 	private _expanded: boolean;
 	private hintHovered = false;
 	private expandedBody: { width: number; lines: string[] } | undefined;
+	private collapsedMemo:
+		| {
+				width: number;
+				previewLines: number;
+				hintHovered: boolean;
+				expandAction: string | undefined;
+				lines: string[];
+		  }
+		| undefined;
 
 	constructor(
 		heading: string,
@@ -294,6 +329,7 @@ export class ThinkingPreviewBlock implements Component {
 	}
 
 	setExpanded(expanded: boolean): void {
+		if (this._expanded !== expanded) this.collapsedMemo = undefined;
 		this._expanded = expanded;
 		if (expanded) expandedThinking.add(this.messageTimestamp);
 		else {
@@ -303,6 +339,7 @@ export class ThinkingPreviewBlock implements Component {
 	}
 
 	setHintHovered(hovered: boolean): void {
+		if (this.hintHovered !== hovered) this.collapsedMemo = undefined;
 		this.hintHovered = hovered;
 	}
 
@@ -362,16 +399,39 @@ export class ThinkingPreviewBlock implements Component {
 			});
 			return box.render(width);
 		}
+
+		const expandAction = thinkingExpandAction();
+		if (
+			this.collapsedMemo?.width === width &&
+			this.collapsedMemo.previewLines === config.previewLines &&
+			this.collapsedMemo.hintHovered === this.hintHovered &&
+			this.collapsedMemo.expandAction === expandAction
+		) {
+			return this.collapsedMemo.lines;
+		}
+
 		const body = this.bodyLines(width, this.padding);
 		const heading = this.headingLines(width, body.hiddenLines, this.padding);
-		if (!body.lines.length) return heading;
-		return [
-			...heading,
-			...body.lines.map((line) => padPreviewLine(this.style(line), width, this.padding)),
-		];
+		const lines = body.lines.length
+			? [
+					...heading,
+					...body.lines.map((line) => padPreviewLine(this.style(line), width, this.padding)),
+				]
+			: heading;
+		this.collapsedMemo = {
+			width,
+			previewLines: config.previewLines,
+			hintHovered: this.hintHovered,
+			expandAction,
+			lines,
+		};
+		return lines;
 	}
 
-	invalidate() {}
+	invalidate() {
+		this.collapsedMemo = undefined;
+		this.expandedBody = undefined;
+	}
 }
 
 function parseSummaryPart(text: string): SummaryPart | undefined {
@@ -922,6 +982,7 @@ function compactThinking(pi: ExtensionAPI) {
 		completedDurations.clear();
 		streamingComponents.clear();
 		expandedThinking.clear();
+		clearThinkingPreviewCache();
 		if (ctx.mode === "tui") ctx.ui.setWidget(WIDGET_ID, undefined);
 
 		if (patchInstalled) {

--- a/extensions/renderer/tool/grouping.ts
+++ b/extensions/renderer/tool/grouping.ts
@@ -180,11 +180,13 @@ export class ToolGroupComponent extends Container {
 	}
 
 	addTool(tool: any): void {
+		this.settledCache = undefined;
 		this.children.push(tool);
 		tool[PARENT_KEY] = this;
 	}
 
 	releaseTools(): any[] {
+		this.settledCache = undefined;
 		const tools = [...this.children];
 		this.children.length = 0;
 		this.patch.groups.delete(this);
@@ -192,18 +194,21 @@ export class ToolGroupComponent extends Container {
 	}
 
 	removeTool(tool: any): void {
+		this.settledCache = undefined;
 		const index = this.children.indexOf(tool);
 		if (index >= 0) this.children.splice(index, 1);
 		if (tool?.[PARENT_KEY] === this) delete tool[PARENT_KEY];
 	}
 
 	setExpanded(expanded: boolean): void {
+		if (this._expanded !== expanded) this.settledCache = undefined;
 		this._expanded = expanded;
 		for (const tool of this.children)
 			(tool as Component & { setExpanded?: (expanded: boolean) => void }).setExpanded?.(expanded);
 	}
 
 	setHintHovered(hovered: boolean): void {
+		if (this.hintHovered !== hovered) this.settledCache = undefined;
 		this.hintHovered = hovered;
 	}
 
@@ -232,6 +237,7 @@ export class ToolGroupComponent extends Container {
 	}
 
 	invalidate(): void {
+		this.settledCache = undefined;
 		for (const tool of this.children) tool.invalidate?.();
 	}
 

--- a/tests/compact-thinking.test.ts
+++ b/tests/compact-thinking.test.ts
@@ -8,8 +8,11 @@ import type { AssistantMessage } from "@earendil-works/pi-ai";
 
 import {
 	animateCompactThinkingText,
+	clearThinkingPreviewCache,
 	installCompactThinking,
 	ThinkingPreviewBlock,
+	thinkingPreviewCacheSize,
+	THINKING_PREVIEW_CACHE_MAX,
 } from "../extensions/feature/compact-thinking.ts";
 
 const config = {
@@ -17,6 +20,66 @@ const config = {
 	previewLines: 0,
 	animationIntervalMs: 30,
 };
+
+test("collapsed thinking previews memoize complete output until invalidated", () => {
+	const originalConfig = { ...config };
+	const { pi } = runtime();
+	const controller = installCompactThinking(pi, { ...originalConfig });
+	controller.updateConfig({ ...originalConfig, previewLines: 1 });
+	clearThinkingPreviewCache();
+	try {
+		const preview = new ThinkingPreviewBlock(
+			"Thought",
+			"alpha beta gamma delta epsilon zeta eta theta",
+			0,
+			1,
+			(text) => text,
+		);
+		const first = preview.render(12);
+		assert.ok(
+			first.some((line) => line.includes("more")),
+			"composed output includes its hint",
+		);
+		assert.strictEqual(preview.render(12), first, "same state reuses complete output");
+
+		assert.notStrictEqual(preview.render(16), first, "width changes recompute output");
+		const beforeConfigChange = preview.render(16);
+		controller.updateConfig({ ...originalConfig, previewLines: 2 });
+		assert.notStrictEqual(
+			preview.render(16),
+			beforeConfigChange,
+			"preview-line changes recompute output",
+		);
+
+		const beforeHover = preview.render(16);
+		preview.setHintHovered(true);
+		assert.notStrictEqual(preview.render(16), beforeHover, "hover changes recompute output");
+
+		const beforeInvalidation = preview.render(16);
+		preview.invalidate();
+		assert.notStrictEqual(preview.render(16), beforeInvalidation, "invalidation clears memo");
+	} finally {
+		controller.updateConfig(originalConfig);
+		clearThinkingPreviewCache();
+	}
+});
+
+test("thinking preview cache evicts one entry instead of clearing", () => {
+	const originalConfig = { ...config };
+	const { pi } = runtime();
+	const controller = installCompactThinking(pi, { ...originalConfig });
+	controller.updateConfig({ ...originalConfig, previewLines: 20 });
+	clearThinkingPreviewCache();
+	try {
+		for (let index = 0; index <= THINKING_PREVIEW_CACHE_MAX; index++) {
+			new ThinkingPreviewBlock("Thought", `preview-${index}`, 0, index, (text) => text).render(80);
+		}
+		assert.equal(thinkingPreviewCacheSize(), THINKING_PREVIEW_CACHE_MAX);
+	} finally {
+		controller.updateConfig(originalConfig);
+		clearThinkingPreviewCache();
+	}
+});
 
 test("compact summary reuses compact-thinking's sweep animation", () => {
 	const theme = {

--- a/tests/tool-grouping.test.ts
+++ b/tests/tool-grouping.test.ts
@@ -281,6 +281,29 @@ test("off refresh ungroups, reload rescans existing tools, and stale shutdown pr
 	assert.equal(prototype.addChild, originalAdd);
 });
 
+test("pending and expanded groups bypass settled render caching", () => {
+	const hooks = installToolGrouping(() => true);
+	try {
+		const parent = new Container() as any;
+		const read = tool("read", "live-read");
+		const bash = tool("bash", "live-bash");
+		parent.addChild(read);
+		parent.addChild(bash);
+		const group = parent.children[0] as ToolGroupComponent;
+
+		const pending = group.render(120);
+		assert.notStrictEqual(group.render(120), pending, "pending spinner output is not memoized");
+
+		read.updateResult({ content: [], isError: false });
+		bash.updateResult({ content: [], isError: false });
+		group.setExpanded(true);
+		const expanded = group.render(120);
+		assert.notStrictEqual(group.render(120), expanded, "expanded child output is not memoized");
+	} finally {
+		hooks.shutdown();
+	}
+});
+
 test("settled collapsed groups reuse the last render until inputs change", () => {
 	const hooks = installToolGrouping(() => true);
 	hooks.setTheme({ fg: (_color: string, text: string) => text });
@@ -296,6 +319,10 @@ test("settled collapsed groups reuse the last render until inputs change", () =>
 
 		const first = group.render(120);
 		assert.strictEqual(group.render(120), first, "identical settled frame reuses the cached lines");
+		group.invalidate();
+		const invalidated = group.render(120);
+		assert.notStrictEqual(invalidated, first, "invalidation clears settled output");
+		assert.strictEqual(group.render(120), invalidated, "new output is memoized");
 
 		const wider = group.render(160);
 		assert.notStrictEqual(wider, first);
@@ -321,11 +348,13 @@ test("settled collapsed groups reuse the last render until inputs change", () =>
 		const expanded = group.render(160);
 		assert.notStrictEqual(expanded, failed);
 		group.setExpanded(false);
-		assert.strictEqual(group.render(160), failed, "collapse reuses the last settled frame");
+		const collapsed = group.render(160);
+		assert.notStrictEqual(collapsed, failed, "expansion changes clear settled output");
+		assert.strictEqual(group.render(160), collapsed, "collapsed output is memoized again");
 
 		parent.addChild(tool("grep", "cached-grep", { pattern: "todo" }));
 		const grown = group.render(160);
-		assert.notStrictEqual(grown, failed);
+		assert.notStrictEqual(grown, collapsed);
 		assert.match(grown.join("\n"), /running/);
 		assert.match(grown.join("\n"), /<success>1<\/success> done/);
 		assert.match(grown.join("\n"), /<error>1<\/error> failed/);


### PR DESCRIPTION
Long sessions rerender hundreds of unchanged thinking previews on every animation frame. The shared preview cache also clears all 500 entries when it fills, which causes repeated wrapping once a transcript exceeds that size.

Cache each collapsed preview's complete rendered output across frames and replace the clear-all cache with a bounded 2,048-entry LRU for rebuilt streaming components. Clear memoized output when display state changes, and tighten invalidation of the settled tool-group cache already present on `main`.

This builds on #7, which bounded the amount of source text wrapped for each preview.
